### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-wrangler.yml
+++ b/.github/workflows/validate-wrangler.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Validate Wrangler Configuration
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/brainsait-store/security/code-scanning/1](https://github.com/Fadil369/brainsait-store/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. Since the workflow only checks out code and runs validation scripts, it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow file, just below the `name:` field and before the `on:` block. This will apply the permission restriction to all jobs in the workflow. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
