### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/backend/app/api/v1/app_store.py
+++ b/backend/app/api/v1/app_store.py
@@ -4,6 +4,7 @@ Handles receipt validation, subscription management, and notifications
 """
 
 from fastapi import APIRouter, Depends, HTTPException, status, Request
+import logging
 from sqlalchemy.orm import Session
 from typing import Dict, Any
 from pydantic import BaseModel
@@ -141,10 +142,10 @@ async def handle_server_notifications(
         
     except Exception as e:
         # Log the error but return 200 to prevent retries
-        print(f"Notification processing error: {str(e)}")
+        logging.error(f"Notification processing error: {str(e)}", exc_info=True)
         return {
             "success": False,
-            "error": str(e),
+            "error": "Internal server error",
             "message": "Notification processing failed"
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/brainsait-store/security/code-scanning/4](https://github.com/Fadil369/brainsait-store/security/code-scanning/4)

To fix the problem, we should avoid returning the raw exception message (`str(e)`) to the client. Instead, we should log the error server-side (using a proper logging mechanism, not just `print`), and return a generic error message in the response. This change should be made in the `handle_server_notifications` function in `backend/app/api/v1/app_store.py`, specifically in the block that handles exceptions (lines 142–149). Additionally, we should replace the `print` statement with a call to Python's `logging` module for better error tracking. If the logging module is not already imported, we should add the import at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
