### PR TITLE
Potential fix for code scanning alert no. 2: LDAP query built from user-controlled sources

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -523,16 +523,16 @@ async def authenticate_ldap(ad_config: TenantSSO, username: str, password: str) 
     
     try:
         import ldap3
-        
+        from ldap3.utils.conv import escape_filter_chars
         # Create LDAP connection
         server = ldap3.Server(ad_config.ldap_server, get_info=ldap3.ALL)
         
         # Bind with user credentials
         user_dn = f"{username}@{ad_config.domain}" if "@" not in username else username
-        
+        safe_user_dn = escape_filter_chars(user_dn)
         with ldap3.Connection(server, user=user_dn, password=password, auto_bind=True) as conn:
             # Search for user attributes
-            search_filter = f"(userPrincipalName={user_dn})"
+            search_filter = f"(userPrincipalName={safe_user_dn})"
             conn.search(
                 ad_config.base_dn,
                 search_filter,


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/brainsait-store/security/code-scanning/2](https://github.com/Fadil369/brainsait-store/security/code-scanning/2)

To fix the problem, user input must be properly escaped before being included in the LDAP search filter. In Python 3, when using the `ldap3` library, the recommended way is to use `ldap3.utils.conv.escape_filter_chars` to escape any user input that will be interpolated into an LDAP filter. This prevents special characters from altering the meaning of the query.

Specifically, in `authenticate_ldap`, before constructing `search_filter`, the `user_dn` (which is derived from user input) should be escaped using `escape_filter_chars`. This requires importing `escape_filter_chars` from `ldap3.utils.conv`. The change should be made in the `authenticate_ldap` function, and the import should be added at the top of the function (since the rest of the code only imports `ldap3` inside the function).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
