### PR TITLE
Potential fix for code scanning alert no. 3: Full server-side request forgery

### DIFF
--- a/backend/app/api/v1/payments.py
+++ b/backend/app/api/v1/payments.py
@@ -14,6 +14,7 @@ import hmac
 import hashlib
 import json
 import httpx
+import urllib.parse
 from datetime import datetime, timedelta
 import logging
 
@@ -498,6 +499,18 @@ async def validate_apple_pay_merchant(
 ):
     """Validate Apple Pay merchant session"""
     
+    # Validate that the validation_url is an Apple Pay domain
+    parsed_url = urllib.parse.urlparse(validation_url)
+    hostname = parsed_url.hostname
+    if not hostname or not (
+        hostname.endswith(".apple.com") or
+        hostname == "apple-pay-gateway.apple.com"
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid validation_url: must be an Apple Pay domain"
+        )
+
     try:
         validation_data = {
             "merchantIdentifier": settings.APPLE_PAY_MERCHANT_ID,


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/brainsait-store/security/code-scanning/3](https://github.com/Fadil369/brainsait-store/security/code-scanning/3)

To fix this SSRF vulnerability, we must ensure that the `validation_url` parameter is restricted to only allow URLs that are legitimate Apple Pay validation endpoints. The best way to do this is to parse the URL and check that its hostname matches the expected Apple domains (e.g., ends with `.apple.com` or is exactly `apple-pay-gateway.apple.com`). If the URL does not match, the request should be rejected with an appropriate error. This change should be made in the `validate_apple_pay_merchant` function in `backend/app/api/v1/payments.py`, before making the HTTP request. We will need to import `urllib.parse` to safely parse and inspect the URL.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
