### PR TITLE
Potential fix for code scanning alert no. 3: Full server-side request forgery

### DIFF
--- a/backend/app/api/v1/payments.py
+++ b/backend/app/api/v1/payments.py
@@ -502,13 +502,22 @@ async def validate_apple_pay_merchant(
     # Validate that the validation_url is an Apple Pay domain
     parsed_url = urllib.parse.urlparse(validation_url)
     hostname = parsed_url.hostname
-    if not hostname or not (
-        hostname.endswith(".apple.com") or
-        hostname == "apple-pay-gateway.apple.com"
+    scheme = parsed_url.scheme
+    allowed_hostnames = {
+        "apple-pay-gateway.apple.com",
+        "apple-pay-gateway-nc.apple.com",
+        "apple-pay-gateway-pr.apple.com",
+        "apple-pay-gateway-aus.apple.com",
+        "apple-pay-gateway-cert.apple.com",
+    }
+    if (
+        scheme != "https"
+        or not hostname
+        or hostname not in allowed_hostnames
     ):
         raise HTTPException(
             status_code=400,
-            detail="Invalid validation_url: must be an Apple Pay domain"
+            detail="Invalid validation_url: must be a valid Apple Pay gateway domain over HTTPS"
         )
 
     try:


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/brainsait-store/security/code-scanning/3](https://github.com/Fadil369/brainsait-store/security/code-scanning/3)

To fix the SSRF vulnerability, we should not allow the user to specify the full URL. Instead, we should maintain a strict allowlist of valid Apple Pay validation endpoints, and only allow requests to those endpoints. If Apple Pay requires the use of a specific set of domains, we can map the user input to a known valid endpoint, or at least validate the scheme, hostname, and port strictly. The fix will involve:

- Validating that the scheme is HTTPS.
- Validating that the hostname is exactly one of the allowed Apple Pay endpoints (not just endswith).
- Optionally, maintaining a set of allowed hostnames and only allowing requests to those.
- Rejecting any URLs that do not match the strict criteria.

The changes will be made in the `/apple-pay/validate` endpoint, specifically in the validation logic for `validation_url`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
